### PR TITLE
{WIP}: IoTMiddlewareForFreeRTOS-XXXX: Adding reconnection failures. Also improving code to connect only once and send telemetry in loop

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
-    "cmake.generator": "Ninja"
+    "cmake.generator": "Ninja",
+    "files.associations": {
+        "azure_sample_crypto.h": "c"
+    }
 }

--- a/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
+++ b/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
@@ -7,6 +7,11 @@
 /* FreeRTOS config include. */
 #include "FreeRTOSConfig.h"
 
+// SAGAR: This is to allow me to work both at home and office.
+// In actual pilot or test setup, we need to hardcode the Wi-Fi credentials and
+// other necessary stuffs.
+// #define HOME_SETUP
+
 /*
  * This plug-and-play model can be found at:
  * https://github.com/Azure/iot-plugandplay-models/blob/main/dtmi/com/example/thermostat-1.json
@@ -75,8 +80,10 @@ extern void vLoggingPrintf( const char * pcFormatString,
  *
  * @note https://docs.microsoft.com/azure/iot-dps/concepts-service#id-scope
  *
+ * @note This is the DPS ID Scope we have in Skytree Azure backend
+ * 
  */
-    #define democonfigID_SCOPE           "<YOUR ID SCOPE HERE>"
+    #define democonfigID_SCOPE           "0ne00AFD579"
 
 /**
  * @brief Registration Id of provisioning service
@@ -85,7 +92,15 @@ extern void vLoggingPrintf( const char * pcFormatString,
  *
  *  @note https://docs.microsoft.com/azure/iot-dps/concepts-service#registration-id
  */
-    #define democonfigREGISTRATION_ID    "<YOUR REGISTRATION ID HERE>"
+
+    // SAGAR: This is to allow me to work both at home and office.
+    // In actual pilot/ test we need to define a registration id per individual enrollment
+    // for ease. @note - The same name is used as device id
+    #ifdef HOME_SETUP
+        #define democonfigREGISTRATION_ID    "skytree_iotkit_home" // home
+    #else
+        #define democonfigREGISTRATION_ID    "skytree_iotkit_ofc" // office
+    #endif
 
 #endif /* democonfigENABLE_DPS_SAMPLE */
 
@@ -112,7 +127,12 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * @brief Device symmetric key
  *
  */
-#define democonfigDEVICE_SYMMETRIC_KEY    "<Symmetric key>"
+// SAGAR: This is to allow me to work both at home and office.
+#ifdef HOME_SETUP
+    #define democonfigDEVICE_SYMMETRIC_KEY    "5Y53mc7C7vwmhumMCgj441h7CvdXo+Kr4xxSFUJzYP67vhCWrPvEzMeHIJISFqEp4hO4r6gJykKfW2OzQkjb/w==" // home device
+#else
+    #define democonfigDEVICE_SYMMETRIC_KEY    "dmazjdey+JxsIW6IUTgqQaS38sHg2ONV42T30VxrfqNtVyNVj8YJa7i8e7CbsJnwL1TYhCFCyUqWoy2bSf72ZQ==" // Office device
+#endif
 
 /**
  * @brief Client's X509 Certificate.
@@ -235,13 +255,23 @@ extern void vLoggingPrintf( const char * pcFormatString,
  * @brief Wifi SSID
  *
  */
-#define WIFI_SSID                            "<SSID>"
+// SAGAR: This is to allow me to work both at home and office.
+#ifdef HOME_SETUP
+    #define WIFI_SSID                            "TMNL-8D9B4C" // home
+#else
+    #define WIFI_SSID                            "Skytree" // office
+#endif
 
 /**
  * @brief Wifi Password
  *
  */
-#define WIFI_PASSWORD                        "<Password>"
+// SAGAR: This is to allow me to work both at home and office.
+#ifdef HOME_SETUP
+    #define WIFI_PASSWORD                        "XYXMNAELRS65BH8A" // home
+#else
+    #define WIFI_PASSWORD                        "5kytr335t4ff" // office
+#endif
 
 /**
  * @brief WIFI Security type, the security types are defined in wifi.h.

--- a/demos/projects/ST/b-l475e-iot01a/main.c
+++ b/demos/projects/ST/b-l475e-iot01a/main.c
@@ -142,6 +142,7 @@ int main( void )
     /* Start the scheduler.  Initialization that requires the OS to be running,
      * including the WiFi initialization, is performed in the RTOS daemon task
      * startup hook. */
+    configPRINTF( ( "---------STARTING Scheduler---------\r\n" ) );
     vTaskStartScheduler();
 
     return 0;

--- a/demos/projects/ST/b-l475e-iot01a/st_code/es_wifi.c
+++ b/demos/projects/ST/b-l475e-iot01a/st_code/es_wifi.c
@@ -2309,7 +2309,7 @@ ES_WIFI_Status_t ES_WIFI_ReceiveData(ES_WIFIObject_t *Obj, uint8_t Socket, uint8
           ret = AT_RequestReceiveData(Obj, Obj->CmdData, (char *)pdata, Reqlen, Receivedlen);
           if (ret != ES_WIFI_STATUS_OK)
           {
-            DEBUG("AT_RequestReceiveData  failed\n");
+            DEBUG("AT_RequestReceiveData failed with return code = %d\n", ret);
           }
         }
         else

--- a/demos/sample_azure_iot/sample_azure_iot.c
+++ b/demos/sample_azure_iot/sample_azure_iot.c
@@ -28,6 +28,30 @@
 /* Crypto helper header. */
 #include "azure_sample_crypto.h"
 
+// Overriding the asserts to let IoT connectivity continue.
+// @todo: Before restarting unsubscribing and TLS disconnect might not
+//        need to be done because the assert might be because of
+//        several software reasons (just not TLS/ socket disconnection).
+// @todo: We may not need this in PCBA but it might be good to check
+//        if the TLS issue happens with ethernet too.
+#include "stm32l4xx_hal.h"
+#undef configASSERT
+#define configASSERT( x )                                                    \
+    if( ( x ) == 0 )                                                         \
+    {                                                                        \
+        vLoggingPrintf( "[FATAL] [%s:%d] %s\r\n", __func__, __LINE__, # x ); \
+        NVIC_SystemReset();                                                  \
+    }
+
+// For the real asserts where we dont want a system reset
+#define configASSERTReal( x )                                                    \
+    if( ( x ) == 0 )                                                         \
+    {                                                                        \
+        vLoggingPrintf( "[FATAL] [%s:%d] %s\r\n", __func__, __LINE__, # x ); \
+        taskDISABLE_INTERRUPTS();                                            \
+        for( ; ; ) {; }                                                      \
+    }
+
 /*-----------------------------------------------------------*/
 
 /* Compile time error for undefined configs. */
@@ -102,8 +126,10 @@
 /**
  * @brief Time in ticks to wait between each cycle of the demo implemented
  * by prvMQTTDemoTask().
+ * 
+ * @todo: Time interval is taken 10 seconds for now, to be adjusted more TBD
  */
-#define sampleazureiotDELAY_BETWEEN_DEMO_ITERATIONS_TICKS     ( pdMS_TO_TICKS( 5000U ) )
+#define sampleazureiotDELAY_BETWEEN_DEMO_ITERATIONS_TICKS     ( pdMS_TO_TICKS( 10000U ) )
 
 /**
  * @brief Timeout for MQTT_ProcessLoop in milliseconds.
@@ -117,7 +143,7 @@
  * Note that the process loop also has a timeout, so the total time between
  * publishes is the sum of the two delays.
  */
-#define sampleazureiotDELAY_BETWEEN_PUBLISHES_TICKS           ( pdMS_TO_TICKS( 2000U ) )
+#define sampleazureiotDELAY_BETWEEN_PUBLISHES_TICKS           ( pdMS_TO_TICKS( 10000U ) )
 
 /**
  * @brief Transport timeout in milliseconds for transport send and receive.
@@ -305,12 +331,24 @@ static uint32_t prvSetupNetworkCredentials( NetworkCredentials_t * pxNetworkCred
 /**
  * @brief Azure IoT demo task that gets started in the platform specific project.
  *  In this demo task, middleware API's are used to connect to Azure IoT Hub.
+ * 
+ *  Connection:
+ *      - Connect and initialize Azure IoT client
+ *      - Do IoTHub related initialization
+ *      - subscribe to topics/ properties etc
+ *      - Start sending telemetry and try to receive properties in a loop every few seconds
+ *  On Failures:
+ *      - Close/ shutdown wifi, sockets etc
+ *      - Re-initialize all drivers, socket layers etc
+ *      - Re-connect
+ *  @todo handle configAssert --> re-connection/ re-try
+ *        Probably we can continue (try re-connecting) instead of an assert
+ * 
  */
 static void prvAzureDemoTask( void * pvParameters )
 {
     int lPublishCount = 0;
     uint32_t ulScratchBufferLength = 0U;
-    const int lMaxPublishCount = 5;
     NetworkCredentials_t xNetworkCredentials = { 0 };
     AzureIoTTransportInterface_t xTransport;
     NetworkContext_t xNetworkContext = { 0 };
@@ -353,8 +391,12 @@ static void prvAzureDemoTask( void * pvParameters )
     #endif /* democonfigENABLE_DPS_SAMPLE */
 
     xNetworkContext.pParams = &xTlsTransportParams;
-
-    for( ; ; )
+    
+    /**
+     * Initiate connection to IoTHub
+     * @todo: We will have an initiate_connection() type of functionality
+     *        to re-start (re-connect) the backoff algorithm.
+    */
     {
         if( xAzureSample_IsConnectedToInternet() )
         {
@@ -409,10 +451,20 @@ static void prvAzureDemoTask( void * pvParameters )
 
             xResult = AzureIoTHubClient_SubscribeCloudToDeviceMessage( &xAzureIoTHubClient, prvHandleCloudMessage,
                                                                        &xAzureIoTHubClient, sampleazureiotSUBSCRIBE_TIMEOUT );
+
+            // Added for debugging, to be removed later
+            if (xResult != eAzureIoTSuccess) {
+                LogInfo( ( "AzureIoTHubClient_SubscribeCloudToDeviceMessage failed with xResult = %d.\r\n", xResult ) );
+            }
+
             configASSERT( xResult == eAzureIoTSuccess );
 
             xResult = AzureIoTHubClient_SubscribeCommand( &xAzureIoTHubClient, prvHandleCommand,
                                                           &xAzureIoTHubClient, sampleazureiotSUBSCRIBE_TIMEOUT );
+            // Added for debugging, to be removed later
+            if (xResult != eAzureIoTSuccess) {
+                LogInfo( ( "AzureIoTHubClient_SubscribeCommand failed with xResult = %d.\r\n", xResult ) );
+            }
             configASSERT( xResult == eAzureIoTSuccess );
 
             xResult = AzureIoTHubClient_SubscribeProperties( &xAzureIoTHubClient, prvHandlePropertiesMessage,
@@ -443,11 +495,17 @@ static void prvAzureDemoTask( void * pvParameters )
             xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag, ( uint8_t * ) "name", sizeof( "name" ) - 1,
                                                         ( uint8_t * ) "value", sizeof( "value" ) - 1 );
             configASSERT( xResult == eAzureIoTSuccess );
+        }
+    }   // Endof connection initialization
 
-            /* Publish messages with QoS1, send and process Keep alive messages. */
-            for( lPublishCount = 0;
-                 lPublishCount < lMaxPublishCount && xAzureSample_IsConnectedToInternet();
-                 lPublishCount++ )
+
+    /**
+     * Try sending telemetry and properties
+    */
+   {
+        if( xAzureSample_IsConnectedToInternet() )
+        {
+            for ( ; ; )
             {
                 ulScratchBufferLength = snprintf( ( char * ) ucScratchBuffer, sizeof( ucScratchBuffer ),
                                                   sampleazureiotMESSAGE, lPublishCount );
@@ -461,6 +519,10 @@ static void prvAzureDemoTask( void * pvParameters )
                                                          sampleazureiotPROCESS_LOOP_TIMEOUT_MS );
                 configASSERT( xResult == eAzureIoTSuccess );
 
+                // Keep the same logic and send properties (alternatively)
+                // @todo: Maybe we can skip and not send properties for pilots
+                //               as we are not using properties for pilots/ test.
+                lPublishCount++;
                 if( lPublishCount % 2 == 0 )
                 {
                     /* Send reported property every other cycle */
@@ -473,40 +535,37 @@ static void prvAzureDemoTask( void * pvParameters )
                 }
 
                 /* Leave Connection Idle for some time. */
-                LogInfo( ( "Keeping Connection Idle...\r\n\r\n" ) );
+                LogInfo( ( "Keeping Connection Idle for %d seconds\r\n\r\n", sampleazureiotDELAY_BETWEEN_PUBLISHES_TICKS / 1000 ) );
                 vTaskDelay( sampleazureiotDELAY_BETWEEN_PUBLISHES_TICKS );
             }
-
-            if( xAzureSample_IsConnectedToInternet() )
-            {
-                xResult = AzureIoTHubClient_UnsubscribeProperties( &xAzureIoTHubClient );
-                configASSERT( xResult == eAzureIoTSuccess );
-
-                xResult = AzureIoTHubClient_UnsubscribeCommand( &xAzureIoTHubClient );
-                configASSERT( xResult == eAzureIoTSuccess );
-
-                xResult = AzureIoTHubClient_UnsubscribeCloudToDeviceMessage( &xAzureIoTHubClient );
-                configASSERT( xResult == eAzureIoTSuccess );
-
-                /* Send an MQTT Disconnect packet over the already connected TLS over
-                 * TCP connection. There is no corresponding response for the disconnect
-                 * packet. After sending disconnect, client must close the network
-                 * connection. */
-                xResult = AzureIoTHubClient_Disconnect( &xAzureIoTHubClient );
-                configASSERT( xResult == eAzureIoTSuccess );
-            }
-
-            /* Close the network connection.  */
-            TLS_Socket_Disconnect( &xNetworkContext );
-
-            /* Wait for some time between two iterations to ensure that we do not
-             * bombard the IoT Hub. */
-            LogInfo( ( "Demo completed successfully.\r\n" ) );
         }
+   }
 
-        LogInfo( ( "Short delay before starting the next iteration.... \r\n\r\n" ) );
-        vTaskDelay( sampleazureiotDELAY_BETWEEN_DEMO_ITERATIONS_TICKS );
+    /**
+     * @todo Handle closure outside so that we can work on re-connection upon failure.
+     * For now leaving it here as is. In fact it should never reavch here.
+    */
+    if( xAzureSample_IsConnectedToInternet() )
+    {
+        xResult = AzureIoTHubClient_UnsubscribeProperties( &xAzureIoTHubClient );
+        configASSERTReal( xResult == eAzureIoTSuccess );
+
+        xResult = AzureIoTHubClient_UnsubscribeCommand( &xAzureIoTHubClient );
+        configASSERTReal( xResult == eAzureIoTSuccess );
+
+        xResult = AzureIoTHubClient_UnsubscribeCloudToDeviceMessage( &xAzureIoTHubClient );
+        configASSERTReal( xResult == eAzureIoTSuccess );
+
+        /* Send an MQTT Disconnect packet over the already connected TLS over
+            * TCP connection. There is no corresponding response for the disconnect
+            * packet. After sending disconnect, client must close the network
+            * connection. */
+        xResult = AzureIoTHubClient_Disconnect( &xAzureIoTHubClient );
+        configASSERTReal( xResult == eAzureIoTSuccess );
     }
+
+    /* Close the network connection.  */
+    TLS_Socket_Disconnect( &xNetworkContext );
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
Improvements done:
- We are now connecting only once and we send telemetry every 10 seconds.
- Added macro overriding to do the way we want. We are restarting the kit when we hit a dead-end.

In-progress:
- Testing: Both functionality and longevity are needed.
- Some more changes on cleanup of sockets and MQTT subscription of properties/ commands.

Later:
- We plan to go deeper into root-cause of the socket close issue. I have a hunch that the backend is closing the connection for whatever reason. Having said that, the software also needs to recover in such scenarios.
- We should try to look into MQTT state machine and handle failure possibilities. However, good for now.

@HosseinAmirX @ErkanTree 