### PR TITLE
IoTMiddleware-XXXX: Asking backend to send alert only once, a hack fo…

### DIFF
--- a/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
+++ b/demos/projects/ST/b-l475e-iot01a/config/demo_config.h
@@ -39,7 +39,7 @@
 
 /* Logging configuration for the Demo. */
 #ifndef LIBRARY_LOG_NAME
-    #define LIBRARY_LOG_NAME    "AzureIoTDemo"
+    #define LIBRARY_LOG_NAME    "AzureIoT"
 #endif
 
 #ifndef LIBRARY_LOG_LEVEL
@@ -109,6 +109,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
     #elif defined(GROWY_SETUP)
         #define democonfigREGISTRATION_ID    "skytree_iotkit_growy" // Growy
     #elif defined(FIELDLESS_SETUP)
+        // #define democonfigREGISTRATION_ID    "skytree_iotkit_fieldless_temp" // Fieldless
         #define democonfigREGISTRATION_ID    "skytree_iotkit_fieldless" // Fieldless
     #endif    
 
@@ -147,6 +148,7 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #elif defined(GROWY_SETUP)
     #define democonfigDEVICE_SYMMETRIC_KEY    "IZSNRvTXMzvXRjvB345XEYJF7Q1S9wM1QpgWQ45NE605OrKvA3bNHRAr4ygYGQmlixAEsHfcFyQ0VFdxhY3Byw==" // Growy
 #elif defined(FIELDLESS_SETUP)
+    // #define democonfigDEVICE_SYMMETRIC_KEY    "AjYZM9V1UViZMknEUWDtAV5tjnAqxoOafrk9qE+uLuFan9HNfGowhFkjN3Q9AmLc79LLPKynkHr0k6M1zoCDNg==" // Fieldless
     #define democonfigDEVICE_SYMMETRIC_KEY    "Mi3+4/7x2tPkSin3m42/2EHDTWbvYrPRqUHIJRKhgtlvoy3XnerG+bORK0VW1mbe51EiRK9kEdRBWjZU+POgMw==" // Fieldless
 #endif
 /**

--- a/demos/projects/ST/b-l475e-iot01a/system_data.h
+++ b/demos/projects/ST/b-l475e-iot01a/system_data.h
@@ -15,13 +15,14 @@
 //Includes
 #include "gui_comm_api.h"
 #include <stdio.h>
+#include <stdbool.h>
 
 //Defines
 #define CRC_POLYNOMIAL 0x42
 #define MESSAGE_LENGTH_UNIT_STATUS 62 //UNIT_status 57 bytes + header 4 bytes + crc 1 byte = 62 bytes
 #define MESSAGE_LENGTH_SKID_STATUS 41 //SKID_status 36 bytes + header 4 bytes + crc 1 byte = 41 bytes
 #define MESSAGE_LENGTH_IOT_COMMAND 6 //IOT_COMMAND header 5 bytes + crc 1 byte = 6 bytes
-#define NUMBER_OF_HEATERS 9 // Its an continuous array for now
+#define NUMBER_OF_HEATERS 9 // Its a continuous array for now
 
 #if 0
 // Structures in controllino for reference
@@ -102,14 +103,9 @@ const char* valve_status_stringified[] = {
     "OPENED"         // 1
 };
 
-const char* three_way_vacuum_release_valve_before_condensator_stringified[] = {
-    "three_way_vacuum_release_valve_before_condensator_to_TANK",        // 0
-    "three_way_vacuum_release_valve_before_condensator_to_AIR"          // 1
-};
-
-const char* three_way_valve_after_vacuum_pump_stringified[] = {
-    "three_way_valve_after_vacuum_pump_to_TANK",        // 0
-    "three_way_valve_after_vacuum_pump_to_AIR"          // 1
+const char* three_way_valve_stringified[] = {
+    "to_Tank",        // 0
+    "to_Air"          // 1
 };
 
 const char* component_status_stringified[] = {
@@ -137,19 +133,21 @@ typedef enum{
     Vacuum_Release_State = 5,
     Lock_State = 6,
     Desorb_Setup_State = 7,
-    Safe_State = 8
+    Safe_State = 8,
+    Unlock_State = 9
 }sequence_state_t;
 
 const char* sequence_state_stringified[] = {
-    "Error_Handling",        // 0
-    "Init_State",            // 1
-    "Adsorb_State",          // 2
-    "Evacuation_State",      // 3
-    "Desorb_State",          // 4
-    "Vacuum_Release_State",  // 5
-    "Lock_State",            // 6
-    "Desorb_Setup_State"     // 7
-    "Safe_State"             // 8
+    "Error_Handling",         // 0
+    "Init_State",             // 1
+    "Adsorb_State",           // 2
+    "Evacuation_State",       // 3
+    "Desorb_State",           // 4
+    "Vacuum_Release_State",   // 5
+    "Lock_State",             // 6
+    "Desorb_Setup_State",     // 7
+    "Safe_State",             // 8
+    "Unlock_State"            // 9
 };
 
 typedef enum{
@@ -212,7 +210,8 @@ typedef struct{
     sensor_info_t vacuum_sensor;
     sensor_info_t ambient_humidity;
     sensor_info_t ambient_temperature;
-    // uint32_t errors;    // @todo
+    bool send_alert;
+    uint32_t errors;
 }UNIT_iot_status_t;
 
 typedef struct{
@@ -247,8 +246,101 @@ typedef struct{
     sensor_info_t proportional_valve_pressure;
     sensor_info_t temperature;
     sensor_info_t humidity;
-    // uint32_t errors;    // @todo
+    bool send_alert;
+    uint32_t errors;
 }SKID_iot_status_t;
+
+#if 0   // For reference from Controllino code
+// Unit error codes
+enum ErrorCodes
+{
+    NO_ERROR = 0,
+    /* Errors 1 - 99 reserved for unit errors*/
+    /* Errors 1 - 19 reserved for heater over temperature */
+    /* Errors 11 - 29 reserved for heater under heating / disconnection */
+    VACUUM_SENSOR_FAULT                                 = 90               // Sensor disconnected
+};
+
+// SKID error codes
+enum ErrorCodes
+{
+    NO_ERROR = 0,
+    /* Errors 1 - 99 reserved for unit errors*/
+    TANK_PRESSURE_SENSOR_FAULT                          = 100,              // Sensor disconnected
+    TANK_PRESSURE_SENSOR_OUT_OF_BOUNDARY                = 101,              // Sensor value out of bound
+    TANK_PRESSURE_FAULT                                 = 102,              // Pressure is not what expected
+    /* 100 - 105 reserved for Tank Pressure Sensor errors */
+    PROPORTIONAL_VALVE_PRESSURE_SENSOR_FAULT            = 106,              // Proportional valve sensor is disconnected
+    PROPORTIONAL_VALVE_PRESSURE_OUT_OF_BOUNDARY         = 107,              // Proportional valve pressure value is out of bound
+    PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_1        = 108,              // Proportional valve pressure above 1.1 bar for more than 15 consecutive seconds
+    PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_2        = 109,              // Proportional valve pressure above 1.5 bar for more than 2 consecutive seconds
+    /* 106 - 110 reserved for Proportional Valve Pressure errors */
+    VACUUM_CHAMBER_SENSOR_TIMEOUT_ERROR                 = 111,              // Vacuum sensor didn't reach 20 mBar before timeout
+    /* 10000 - 20000 reserved for warnings*/
+    WARNING_MASS_FLOW_SENSOR_FAULT                      = 10001,            // Mass flow sensor is disconnected or I2C has problem
+    WARNING_O2_SENSOR_FAULT                             = 10002,            // O2 sensor is disconnected or I2C has problem
+    WARNING_CO2_SENSOR_FAULT                            = 10003,            // CO2 sensor is disconnected
+};
+#endif
+
+typedef enum{
+    NO_ERROR = 0,
+    /* Unit errors: Errors 1 - 99 reserved for unit errors*/
+    VACUUM_SENSOR_FAULT                                 = 90,               // Sensor disconnected
+    /* Skid errors */
+    TANK_PRESSURE_SENSOR_FAULT                          = 100,              // Sensor disconnected
+    TANK_PRESSURE_SENSOR_OUT_OF_BOUNDARY                = 101,              // Sensor value out of bound
+    TANK_PRESSURE_FAULT                                 = 102,              // Pressure is not what expected
+    /* 100 - 105 reserved for Tank Pressure Sensor errors */
+    PROPORTIONAL_VALVE_PRESSURE_SENSOR_FAULT            = 106,              // Proportional valve sensor is disconnected
+    PROPORTIONAL_VALVE_PRESSURE_OUT_OF_BOUNDARY         = 107,              // Proportional valve pressure value is out of bound
+    PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_1        = 108,              // Proportional valve pressure above 1.1 bar for more than 15 consecutive seconds
+    PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_2        = 109,              // Proportional valve pressure above 1.5 bar for more than 2 consecutive seconds
+    /* 106 - 110 reserved for Proportional Valve Pressure errors */
+    VACUUM_CHAMBER_SENSOR_TIMEOUT_ERROR                 = 111,              // Vacuum sensor didn't reach 20 mBar before timeout
+    /* 10000 - 20000 reserved for warnings*/
+    WARNING_MASS_FLOW_SENSOR_FAULT                      = 10001,            // Mass flow sensor is disconnected or I2C has problem
+    WARNING_O2_SENSOR_FAULT                             = 10002,            // O2 sensor is disconnected or I2C has problem
+    WARNING_CO2_SENSOR_FAULT                            = 10003,            // CO2 sensor is disconnected
+}ErrorCodes_t;
+
+void stringifyErrorCode(char* error_stringified, ErrorCodes_t code) {
+    switch (code){
+        case NO_ERROR:            
+            sprintf(error_stringified, "%s", "NO_ERROR");
+            break;
+        case VACUUM_SENSOR_FAULT:
+            sprintf(error_stringified, "%s", "VACUUM_SENSOR_FAULT");
+            break;
+        case TANK_PRESSURE_SENSOR_FAULT:
+            sprintf(error_stringified, "%s", "TANK_PRESSURE_SENSOR_FAULT");
+            break;
+        case TANK_PRESSURE_SENSOR_OUT_OF_BOUNDARY:
+            sprintf(error_stringified, "%s", "TANK_PRESSURE_SENSOR_OUT_OF_BOUNDARY");
+            break;
+        case TANK_PRESSURE_FAULT:
+            sprintf(error_stringified, "%s", "TANK_PRESSURE_FAULT");
+            break;
+        case PROPORTIONAL_VALVE_PRESSURE_SENSOR_FAULT:
+            sprintf(error_stringified, "%s", "PROPORTIONAL_VALVE_PRESSURE_SENSOR_FAULT");
+            break;
+        case PROPORTIONAL_VALVE_PRESSURE_OUT_OF_BOUNDARY:
+            sprintf(error_stringified, "%s", "PROPORTIONAL_VALVE_PRESSURE_OUT_OF_BOUNDARY");
+            break;
+        case PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_1:
+            sprintf(error_stringified, "%s", "PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_1");
+            break;
+        case PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_2:
+            sprintf(error_stringified, "%s", "PROPORTIONAL_VALVE_PRESSURE_CRITICAL_STATE_2");
+            break;
+        case VACUUM_CHAMBER_SENSOR_TIMEOUT_ERROR:
+            sprintf(error_stringified, "%s", "VACUUM_CHAMBER_SENSOR_TIMEOUT_ERROR");
+            break;
+        default:
+            sprintf(error_stringified, "%s%d", "UNKNOWN_CODE: ", code);
+            break;
+    }
+}
 
 //Functions
 void system_data_init(void);
@@ -256,8 +348,8 @@ void read_incoming_system_data(void);
 void send_lock_status(void);
 void send_unlock_status(void);
 
-UNIT_iot_status_t get_unit_status(void);
-SKID_iot_status_t get_skid_status(void);
+UNIT_iot_status_t get_unit_status(sequence_state_t last_unit_state);
+SKID_iot_status_t get_skid_status(sequence_state_t last_skid_state);
 
 #ifdef __cplusplus
 }

--- a/demos/sample_azure_iot/sample_azure_iot.c
+++ b/demos/sample_azure_iot/sample_azure_iot.c
@@ -100,7 +100,6 @@
  * @brief The Telemetry message published in this example.
  */
 // #define sampleazureiotMESSAGE                                 "Hello World : %d !"
-// #define sampleazureiotMESSAGE                                 "{\"temperature\":%f,\"humidity\":%f,\"co2\":%f}"
 
 /**
  * @brief Telemetry Values
@@ -108,15 +107,12 @@
 // Primary objects
 #define sampleazureiotTELEMETRY_OBJECT_SKID                       ( "skid" )
 #define sampleazureiotTELEMETRY_OBJECT_UNITS                      ( "units" )
-// #define sampleazureiotTELEMETRY_OBJECT_EXTERNAL                   ( "environment" )
-// #define sampleazureiotTELEMETRY_OBJECT_STATE                      ( "state" )
-// #define sampleazureiotTELEMETRY_OBJECT_ERROR_STATE                ( "error-state" )
 
 // Secondary
 #define sampleazureiotTELEMETRY_OBJECT_UNIT1                      ( "unit1" )
 #define sampleazureiotTELEMETRY_OBJECT_UNIT2                      ( "unit2" )
 #define sampleazureiotTELEMETRY_OBJECT_UNIT3                      ( "unit3" )
-// #define sampleazureiotTELEMETRY_OBJECT_PRESSURE                   ( "pressure" )
+
 // sensor objects
 #define sampleazureiotTELEMETRY_OBJECT_O2                         ( "o2" )
 #define sampleazureiotTELEMETRY_OBJECT_MASSFLOW                   ( "mass_flow" )
@@ -147,6 +143,10 @@
 #define sampleazureiotTELEMETRY_OBJECT_VALVE_STATUS               ( "valve_status" )
 
 // Telemetry
+#define sampleazureiotTELEMETRY_SKID_ALERT                        ( "skid_alert" )
+#define sampleazureiotTELEMETRY_UNIT_ALERT                        ( "unit_alert" )
+#define sampleazureiotTELEMETRY_SKID_ERROR_CODE                   ( "skid_error_code" )
+#define sampleazureiotTELEMETRY_UNIT_ERROR_CODE                   ( "unit_error_code" )
 #define sampleazureiotTELEMETRY_SKID_STATE                        ( "skid_state" )
 #define sampleazureiotTELEMETRY_UNIT_STATE                        ( "unit_state" )
 #define sampleazureiotTELEMETRY_STATUS                            ( "status" )
@@ -173,31 +173,6 @@
 #define sampleazureiotTELEMETRY_FAN_STATUS                                      ( "fan_status" )
 #define sampleazureiotTELEMETRY_BUTTERFLY_VALVE_1_STATUS                        ( "butterfly_valve_1_status" )
 #define sampleazureiotTELEMETRY_BUTTERFLY_VALVE_2_STATUS                        ( "butterfly_valve_2_status" )
-
-// #define sampleazureiotTELEMETRY_PRESSURE1                         ( "pressure1" )
-// #define sampleazureiotTELEMETRY_PRESSURE2                         ( "pressure2" )
-// #define sampleazureiotTELEMETRY_PRESSURE3                         ( "pressure3" )
-// #define sampleazureiotTELEMETRY_MASS_FLOW                         ( "massflow" )
-// #define sampleazureiotTELEMETRY_CO2                               ( "co2" )
-// #define sampleazureiotTELEMETRY_O2                                ( "o2" )
-// #define sampleazureiotTELEMETRY_TEMPERATURE                       ( "ambient_temperature" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE11                       ( "cartridge11" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE12                       ( "cartridge12" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE13                       ( "cartridge13" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE21                       ( "cartridge21" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE22                       ( "cartridge22" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE23                       ( "cartridge23" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE31                       ( "cartridge31" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE32                       ( "cartridge32" )
-// #define sampleazureiotTELEMETRY_CARTRIDGE33                       ( "cartridge33" )
-// #define sampleazureiotTELEMETRY_VACUUM                            ( "vacuum" )
-// #define sampleazureiotTELEMETRY_VIBRATION                         ( "vibration" )
-// #define sampleazureiotTELEMETRY_HUMIDITY                          ( "ambient_humidity" )
-// #define sampleazureiotTELEMETRY_TANK_PRESSURE                     ( "tank_pressure" )
-// #define sampleazureiotTELEMETRY_PWM_DUTY_CYCLE                    ( "pwm_duty_cycle" )
-
-// #define sampleazureiotTELEMETRY_STATUS                     ( "status" )
-// #define sampleazureiotTELEMETRY_ERROR_STATUS               ( "errorstatus" )
 
 // For getting the length of the telemetry names
 #define lengthof( x )                  ( sizeof( x ) - 1 )
@@ -295,6 +270,10 @@ struct NetworkContext
 
 static AzureIoTHubClient_t xAzureIoTHubClient;
 /*-----------------------------------------------------------*/
+
+// Alert related
+sequence_state_t xSkidLastState;
+sequence_state_t xUnitLastState;
 
 #ifdef democonfigENABLE_DPS_SAMPLE
 
@@ -468,12 +447,12 @@ uint32_t prvCreateSkidComponentStatusTelemetry( SKID_iot_status_t skid_data, uin
     configASSERT( xResult == eAzureIoTSuccess );
 
     xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_THREE_WAY_VACUUM_RELEASE_VALVE_BEFORE_CONDENSER, lengthof( sampleazureiotTELEMETRY_THREE_WAY_VACUUM_RELEASE_VALVE_BEFORE_CONDENSER ),
-                                                                ( uint8_t * )three_way_vacuum_release_valve_before_condensator_stringified[skid_data.three_way_vacuum_release_valve_before_condenser],
-                                                                strlen(three_way_vacuum_release_valve_before_condensator_stringified[skid_data.three_way_vacuum_release_valve_before_condenser]));
+                                                                ( uint8_t * )three_way_valve_stringified[skid_data.three_way_vacuum_release_valve_before_condenser],
+                                                                strlen(three_way_valve_stringified[skid_data.three_way_vacuum_release_valve_before_condenser]));
     configASSERT( xResult == eAzureIoTSuccess );
     xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_THREE_WAY_VALVE_AFTER_VACUUM_PUMP, lengthof( sampleazureiotTELEMETRY_THREE_WAY_VALVE_AFTER_VACUUM_PUMP ),
-                                                                ( uint8_t * )three_way_valve_after_vacuum_pump_stringified[skid_data.three_valve_after_vacuum_pump],
-                                                                strlen(three_way_valve_after_vacuum_pump_stringified[skid_data.three_valve_after_vacuum_pump]));
+                                                                ( uint8_t * )three_way_valve_stringified[skid_data.three_valve_after_vacuum_pump],
+                                                                strlen(three_way_valve_stringified[skid_data.three_valve_after_vacuum_pump]));
     configASSERT( xResult == eAzureIoTSuccess )
 
     xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_COMPRESSOR, lengthof( sampleazureiotTELEMETRY_COMPRESSOR ),
@@ -834,11 +813,24 @@ uint32_t prvCreateSkidTelemetry( uint8_t * pucTelemetryData, uint32_t ulTelemetr
     configASSERT( xResult == eAzureIoTSuccess );
 
     // Read the current sensor data
-    SKID_iot_status_t skid_data = get_skid_status();
+    SKID_iot_status_t skid_data = get_skid_status(xSkidLastState);
+    xSkidLastState = skid_data.skid_state;
+
     // Other non-nested stuff
-    xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_SKID_STATE, lengthof( sampleazureiotTELEMETRY_SKID_STATE ),
-                                                                ( uint8_t * )sequence_state_stringified[skid_data.skid_state], strlen(sequence_state_stringified[skid_data.skid_state]));
-    configASSERT( xResult == eAzureIoTSuccess );
+    {
+        xResult = AzureIoTJSONWriter_AppendPropertyWithBoolValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_SKID_ALERT, lengthof( sampleazureiotTELEMETRY_SKID_ALERT ), skid_data.send_alert);
+        configASSERT( xResult == eAzureIoTSuccess );
+
+        char error_code_stringified[60] = {0};
+        stringifyErrorCode(error_code_stringified, skid_data.errors);
+        xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_SKID_ERROR_CODE, lengthof( sampleazureiotTELEMETRY_SKID_ERROR_CODE ),
+                                                                    ( uint8_t * )error_code_stringified, strlen(error_code_stringified));
+        configASSERT( xResult == eAzureIoTSuccess );
+
+        xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_SKID_STATE, lengthof( sampleazureiotTELEMETRY_SKID_STATE ),
+                                                                    ( uint8_t * )sequence_state_stringified[skid_data.skid_state], strlen(sequence_state_stringified[skid_data.skid_state]));
+        configASSERT( xResult == eAzureIoTSuccess );
+    }
 
     // Nested sensors
     // o2
@@ -989,11 +981,25 @@ uint32_t prvCreateUnit1Telemetry( uint8_t * pucTelemetryData, uint32_t ulTelemet
     configASSERT( xResult == eAzureIoTSuccess );
 
     // Read the current sensor data
-    UNIT_iot_status_t unit_data = get_unit_status();
+    UNIT_iot_status_t unit_data = get_unit_status(xUnitLastState);
+    xUnitLastState = unit_data.unit_state;
+
     // Other non-nested stuff
-    xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_UNIT_STATE, lengthof( sampleazureiotTELEMETRY_UNIT_STATE ),
-                                                                ( uint8_t * )sequence_state_stringified[unit_data.unit_state], strlen(sequence_state_stringified[unit_data.unit_state]));
-    configASSERT( xResult == eAzureIoTSuccess );
+    {
+        xResult = AzureIoTJSONWriter_AppendPropertyWithBoolValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_UNIT_ALERT, lengthof( sampleazureiotTELEMETRY_UNIT_ALERT ), unit_data.send_alert);
+        configASSERT( xResult == eAzureIoTSuccess );
+
+        char error_code_stringified[30] = {0};
+        stringifyErrorCode(error_code_stringified, unit_data.errors);
+
+        xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_UNIT_ERROR_CODE, lengthof( sampleazureiotTELEMETRY_UNIT_ERROR_CODE ),
+                                                                    ( uint8_t * )error_code_stringified, strlen(error_code_stringified));
+        configASSERT( xResult == eAzureIoTSuccess );
+
+        xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_UNIT_STATE, lengthof( sampleazureiotTELEMETRY_UNIT_STATE ),
+                                                                    ( uint8_t * )sequence_state_stringified[unit_data.unit_state], strlen(sequence_state_stringified[unit_data.unit_state]));
+        configASSERT( xResult == eAzureIoTSuccess );
+    }
 
     // heaters
     {
@@ -1232,28 +1238,6 @@ uint32_t prvCreateTelemetry( uint8_t * pucTelemetryData, uint32_t ulTelemetryDat
         configASSERT( xResult == eAzureIoTSuccess );
     }
     // Endof Units
-
-    #if 0 // External
-    {
-        xResult = AzureIoTJSONWriter_AppendPropertyName( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_OBJECT_EXTERNAL, lengthof( sampleazureiotTELEMETRY_OBJECT_EXTERNAL ) );
-        configASSERT( xResult == eAzureIoTSuccess );
-
-        // All external sensors
-        memset(ucScratchTempHalfBuffer, '\0', sizeof(ucScratchTempHalfBuffer));
-        lBytesWritten = prvCreateExternalTelemetry(ucScratchTempHalfBuffer, sizeof(ucScratchTempHalfBuffer) );
-
-        xResult = AzureIoTJSONWriter_AppendJSONText( &xWriter, ucScratchTempHalfBuffer, lBytesWritten );
-        configASSERT( xResult == eAzureIoTSuccess );
-    }
-    // Endof External
-
-    // @todo: Remove this and have nested stuff!!!
-    // Temp Status
-    xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_STATUS, lengthof( sampleazureiotTELEMETRY_STATUS ), "Running", 7 );
-    configASSERT( xResult == eAzureIoTSuccess );
-    xResult = AzureIoTJSONWriter_AppendPropertyWithStringValue( &xWriter, ( uint8_t * ) sampleazureiotTELEMETRY_ERROR_STATUS, lengthof( sampleazureiotTELEMETRY_ERROR_STATUS ), "No Error", 8 );
-    configASSERT( xResult == eAzureIoTSuccess );
-    #endif // Endof Temp status
 
     // End top object
     xResult = AzureIoTJSONWriter_AppendEndObject( &xWriter );


### PR DESCRIPTION
For now,
Added a small hack to send alert only once. Ideally the trigger should come from Controllino which means we need to define better communication between SID and IoTKit or define rules to do so.

And simplified the alert mechanism for now like below. We trigger event-hub only when a flag is set,

```
SELECT
    device_id as deviceId,
    skid_skid_state,
    skid_error_code,
    unit1_unit_state,
    unit1_error_code
INTO
    skytreeeventhubalert
FROM
    CTE
WHERE
    skid_alert = 1 OR unit1_alert = 1
```